### PR TITLE
ci: Add GitHub Actions for release/PyPI publishing (optional, for demo)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+# .github/workflows/release.yml
+
+name: Publish Python Package
+
+on:
+  release:
+    types: [published] # Trigger on new GitHub release publication
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Use the latest available 3.x Python version
+
+      - name: Install build tools
+        run: python -m pip install build wheel twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }} # Use a GitHub Secret for your PyPI API token
+        run: twine upload dist/*


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`.github/workflows/release.yml`) to automate the process of building and publishing the Python package to PyPI.

The workflow is configured to trigger automatically upon the creation of a new GitHub Release. It includes the necessary steps for:
- Checking out the repository code.
- Setting up a Python environment.
- Installing Python build and publishing tools (`build`, `wheel`, `twine`).
- Building the sdist and wheel distribution packages.
- Publishing the generated packages to PyPI, utilizing a `PYPI_API_TOKEN` GitHub Secret for authentication.

This addition aligns with Phase 5a's goal of distribution readiness and serves as an optional demonstration of automated CI/CD for package releases.